### PR TITLE
feat: Add IPYNB attachment support

### DIFF
--- a/=5.10.4
+++ b/=5.10.4
@@ -1,0 +1,15 @@
+Collecting nbformat
+  Using cached nbformat-5.10.4-py3-none-any.whl.metadata (3.6 kB)
+Requirement already satisfied: fastjsonschema>=2.15 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from nbformat) (2.21.1)
+Requirement already satisfied: jsonschema>=2.6 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from nbformat) (4.24.0)
+Requirement already satisfied: jupyter-core!=5.0.*,>=4.12 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from nbformat) (5.8.1)
+Requirement already satisfied: traitlets>=5.1 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from nbformat) (5.14.3)
+Requirement already satisfied: attrs>=22.2.0 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from jsonschema>=2.6->nbformat) (25.3.0)
+Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from jsonschema>=2.6->nbformat) (2025.4.1)
+Requirement already satisfied: referencing>=0.28.4 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from jsonschema>=2.6->nbformat) (0.36.2)
+Requirement already satisfied: rpds-py>=0.7.1 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from jsonschema>=2.6->nbformat) (0.25.1)
+Requirement already satisfied: platformdirs>=2.5 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from jupyter-core!=5.0.*,>=4.12->nbformat) (4.3.8)
+Requirement already satisfied: typing-extensions>=4.4.0 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from referencing>=0.28.4->jsonschema>=2.6->nbformat) (4.14.0)
+Using cached nbformat-5.10.4-py3-none-any.whl (78 kB)
+Installing collected packages: nbformat
+Successfully installed nbformat-5.10.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
     "pillow>=11.2.1",
     "pydantic>=2.11.5",
     "pdfplumber>=0.11.6",
-    "pillow-heif>=0.22.0"
+    "pillow-heif>=0.22.0",
+    "nbformat>=5.10.4"  # For IPYNB notebook processing
 ]
 
 [project.urls]

--- a/src/attachments/pipelines/__init__.py
+++ b/src/attachments/pipelines/__init__.py
@@ -213,6 +213,7 @@ from . import webpage_processor
 from . import csv_processor
 from . import vector_graphics_processor
 from . import example_processors
+from . import ipynb_processor
 
 __all__ = [
     'processor', 'processors', 'find_primary_processor', 'find_named_processor',

--- a/src/attachments/pipelines/ipynb_processor.py
+++ b/src/attachments/pipelines/ipynb_processor.py
@@ -1,0 +1,65 @@
+# This file will contain the logic for processing IPYNB files.
+# It will include a matcher, loader, presenter, and processor for IPYNB files.
+
+from attachments.core import Attachment
+
+import nbformat
+from attachments.core import Attachment, loader
+
+def ipynb_match(att: Attachment) -> bool:
+    """Matches IPYNB files based on their extension."""
+    return att.path.lower().endswith(".ipynb")
+
+@loader(match=ipynb_match)
+def ipynb_loader(att: Attachment) -> Attachment:
+    """Loads and parses an IPYNB file."""
+    with open(att.input_source, "r", encoding="utf-8") as f:
+        notebook = nbformat.read(f, as_version=4)
+    att._obj = notebook
+    return att
+
+from attachments.core import presenter
+from nbformat.notebooknode import NotebookNode # Reverted import
+
+@presenter
+def ipynb_text_presenter(att: Attachment, notebook: NotebookNode) -> Attachment:
+    """Presents the IPYNB content as text."""
+    full_content_blocks = []
+    for cell in notebook.cells:
+        cell_block_parts = []
+        if cell.cell_type == "markdown":
+            cell_block_parts.append(cell.source)
+        elif cell.cell_type == "code":
+            cell_block_parts.append(f"```python\n{cell.source}\n```")
+            for output in cell.outputs:
+                if output.output_type == "stream":
+                    text = output.text
+                    if text.endswith("\n"): # Ensure single newline for stream output before closing ```
+                        text = text[:-1]
+                    cell_block_parts.append(f"Output:\n```\n{text}\n```")
+                elif output.output_type == "execute_result":
+                    if "text/plain" in output.data:
+                        text = output.data['text/plain']
+                        if text.endswith("\n"): # Ensure single newline
+                            text = text[:-1]
+                        cell_block_parts.append(f"Output:\n```\n{text}\n```")
+                elif output.output_type == "error":
+                    cell_block_parts.append(f"Error:\n```\n{output.ename}: {output.evalue}\n```")
+
+        if cell_block_parts:
+            full_content_blocks.append("\n".join(cell_block_parts))
+
+    att.text = "\n\n".join(full_content_blocks)
+    return att
+
+from attachments.pipelines import processor
+from attachments import load, present
+
+@processor(
+    match=ipynb_match,
+    description="A processor for IPYNB (Jupyter Notebook) files."
+)
+def ipynb_to_llm(att: Attachment) -> Attachment:
+    """Processes an IPYNB file into an LLM-friendly text format."""
+    from attachments import load, present # Explicit import
+    return att | load.ipynb_loader | present.ipynb_text_presenter

--- a/tests/test_ipynb_processor.py
+++ b/tests/test_ipynb_processor.py
@@ -1,0 +1,257 @@
+import pytest
+from attachments import Attachments
+from attachments.core import Attachment
+from attachments.pipelines.ipynb_processor import ipynb_match, ipynb_loader, ipynb_text_presenter
+import nbformat
+import os
+
+# Create a dummy IPYNB file for testing
+DUMMY_IPYNB_CONTENT = {
+    "nbformat": 4,
+    "nbformat_minor": 5,
+    "metadata": {},
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": "# Title"
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "execution_count": 1,
+            "source": "print('Hello, World!')",
+            "outputs": [
+                {
+                    "output_type": "stream",
+                    "name": "stdout",
+                    "text": "Hello, World!\n"
+                }
+            ]
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "execution_count": 2,
+            "source": "1 + 1",
+            "outputs": [
+                {
+                    "output_type": "execute_result",
+                    "execution_count": 2,
+                    "data": {
+                        "text/plain": "2"
+                    },
+                    "metadata": {}
+                }
+            ]
+        },
+        {
+            "cell_type": "code",
+            "metadata": {},
+            "execution_count": 3,
+            "source": "raise ValueError('Test Error')",
+            "outputs": [
+                {
+                    "output_type": "error",
+                    "ename": "ValueError",
+                    "evalue": "Test Error",
+                    "traceback": ["Traceback (most recent call last)..."]
+                }
+            ]
+        }
+    ]
+}
+
+DUMMY_IPYNB_FILENAME = "dummy_notebook.ipynb"
+
+@pytest.fixture(scope="module", autouse=True)
+def create_dummy_ipynb():
+    notebook_node = nbformat.from_dict(DUMMY_IPYNB_CONTENT)
+    with open(DUMMY_IPYNB_FILENAME, "w", encoding="utf-8") as f:
+        nbformat.write(notebook_node, f)
+    yield
+    os.remove(DUMMY_IPYNB_FILENAME)
+
+def test_ipynb_match():
+    """Test that ipynb_match correctly identifies IPYNB files."""
+    att_ipynb = Attachment("test.ipynb")
+    att_txt = Attachment("test.txt")
+    assert ipynb_match(att_ipynb) is True
+    assert ipynb_match(att_txt) is False
+
+def test_ipynb_loader():
+    """Test that ipynb_loader correctly loads and parses an IPYNB file."""
+    att = Attachment(DUMMY_IPYNB_FILENAME)
+    loaded_att = ipynb_loader(att)
+    assert loaded_att._obj is not None
+    assert isinstance(loaded_att._obj, nbformat.NotebookNode)
+    assert len(loaded_att._obj.cells) == 4
+
+def test_ipynb_presenter():
+    """Test that the IPYNB presenter converts notebook content to text correctly."""
+    att = Attachment(DUMMY_IPYNB_FILENAME)
+    loaded_att = ipynb_loader(att)
+    presented_att = ipynb_text_presenter(loaded_att, loaded_att._obj)
+
+    expected_text = """\
+# Title
+
+```python
+print('Hello, World!')
+```
+Output:
+```
+Hello, World!
+```
+
+```python
+1 + 1
+```
+Output:
+```
+2
+```
+
+```python
+raise ValueError('Test Error')
+```
+Error:
+```
+ValueError: Test Error
+```"""
+    assert presented_att.text.strip() == expected_text.strip()
+
+def test_ipynb_processor_integration():
+    """Test the full IPYNB processor pipeline."""
+    attachments = Attachments(DUMMY_IPYNB_FILENAME)
+    assert len(attachments) == 1
+    att = attachments[0]
+    assert att.path == DUMMY_IPYNB_FILENAME
+
+    expected_text = """\
+# Title
+
+```python
+print('Hello, World!')
+```
+Output:
+```
+Hello, World!
+```
+
+```python
+1 + 1
+```
+Output:
+```
+2
+```
+
+```python
+raise ValueError('Test Error')
+```
+Error:
+```
+ValueError: Test Error
+```"""
+    # Normalize whitespace for comparison
+    processed_text_normalized = "\n".join(line.strip() for line in att.text.strip().splitlines() if line.strip())
+    expected_text_normalized = "\n".join(line.strip() for line in expected_text.strip().splitlines() if line.strip())
+
+    assert processed_text_normalized == expected_text_normalized
+
+def test_ipynb_processor_with_empty_notebook():
+    """Test the processor with an empty IPYNB file."""
+    EMPTY_IPYNB_FILENAME = "empty_notebook.ipynb"
+    empty_content = {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": []
+    }
+    empty_notebook_node = nbformat.from_dict(empty_content)
+    with open(EMPTY_IPYNB_FILENAME, "w", encoding="utf-8") as f:
+        nbformat.write(empty_notebook_node, f)
+
+    attachments = Attachments(EMPTY_IPYNB_FILENAME)
+    assert len(attachments) == 1
+    att = attachments[0]
+    assert att.text == ""
+
+    os.remove(EMPTY_IPYNB_FILENAME)
+
+def test_ipynb_processor_with_markdown_only():
+    """Test the processor with an IPYNB file containing only markdown."""
+    MARKDOWN_ONLY_FILENAME = "markdown_only.ipynb"
+    markdown_content = {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": "## Section 1\nSome text here."
+            },
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": "### Subsection 1.1\nMore text."
+            }
+        ]
+    }
+    markdown_notebook_node = nbformat.from_dict(markdown_content)
+    with open(MARKDOWN_ONLY_FILENAME, "w", encoding="utf-8") as f:
+        nbformat.write(markdown_notebook_node, f)
+
+    attachments = Attachments(MARKDOWN_ONLY_FILENAME)
+    assert len(attachments) == 1
+    att = attachments[0]
+    expected_text = "## Section 1\nSome text here.\n\n### Subsection 1.1\nMore text."
+    assert att.text.strip() == expected_text.strip()
+
+    os.remove(MARKDOWN_ONLY_FILENAME)
+
+def test_ipynb_processor_with_code_only_no_output():
+    """Test the processor with an IPYNB file containing only code cells without output."""
+    CODE_ONLY_NO_OUTPUT_FILENAME = "code_only_no_output.ipynb"
+    code_content = {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": [
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": 1,
+                "source": "x = 10\ny = 20",
+                "outputs": []
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None, # Unexecuted cell
+                "source": "print(x + y)",
+                "outputs": []
+            }
+        ]
+    }
+    code_notebook_node = nbformat.from_dict(code_content)
+    with open(CODE_ONLY_NO_OUTPUT_FILENAME, "w", encoding="utf-8") as f:
+        nbformat.write(code_notebook_node, f)
+
+    attachments = Attachments(CODE_ONLY_NO_OUTPUT_FILENAME)
+    assert len(attachments) == 1
+    att = attachments[0]
+    expected_text = """\
+```python
+x = 10
+y = 20
+```
+
+```python
+print(x + y)
+```"""
+    assert att.text.strip() == expected_text.strip()
+
+    os.remove(CODE_ONLY_NO_OUTPUT_FILENAME)


### PR DESCRIPTION
This commit introduces support for processing IPYNB (Jupyter Notebook) files within the attachments library.

Key changes:
- Added `ipynb_processor.py` in `src/attachments/pipelines/` containing the matcher, loader, presenter, and processor for IPYNB files.
- The loader uses `nbformat` to parse notebook content.
- The presenter converts notebook cells (markdown, code, outputs, errors) into a unified text representation suitable for LLMs.
- Added `nbformat` to project dependencies.
- Included comprehensive tests for the IPYNB processor, covering various notebook structures.

A workaround was implemented by explicitly importing `load` and `present` namespaces within the `ipynb_to_llm` processor function to resolve attribute errors during runtime when the processor is invoked by the Attachments class. This ensures the correct, fully populated namespaces are used.