### PR TITLE
Fix reducer check for OpenAI responses

### DIFF
--- a/src/attachments/core.py
+++ b/src/attachments/core.py
@@ -233,9 +233,9 @@ class AttachmentCollection:
         # Check if it's a refiner that works on collections
         if hasattr(operation, 'name'):
             reducing_operations = {
-                'tile_images', 'combine_images', 'merge_text', 
+                'tile_images', 'combine_images', 'merge_text',
                 'report_unused_commands',
-                'claude', 'openai_chat', 'openai_response'  # Adapters are always reducers
+                'claude', 'openai_chat', 'openai_responses'  # Adapters are always reducers
             }
             return operation.name in reducing_operations
         return False


### PR DESCRIPTION
## Summary
- fix typo in AttachmentCollection reducer list for `openai_responses`

## Testing
- `pytest -q` *(fails: AuthenticationError: OpenAI API key required)*
- `pytest tests/test_api_methods.py tests/test_attachments.py tests/test_excel_to_csv.py tests/test_ipynb_processor.py tests/test_smoke.py -q` *(fails: several assertions and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869258c292883258309299f0d943b7d